### PR TITLE
fix(NonText): adding embed video functionality

### DIFF
--- a/packages/astro-notion/components/NonText.astro
+++ b/packages/astro-notion/components/NonText.astro
@@ -2,6 +2,7 @@
 import Text from './Text.astro';
 import { Img } from 'astro-imagetools/components';
 import { downloadFile } from '../api/utils.ts'
+import urlParser from 'js-video-url-parser';
 const { as: NonText, block } = Astro.props;
 
 const contentType = block.type
@@ -26,8 +27,8 @@ if (fileType === 'external') {
   const getCleanUrl = (url: string) => {
     const cleanUrl = url.split('?')
     if (contentType === 'video') {
-      const youtubeUrl = cleanUrl[0].replace(/\.be\//, 'be.com/embed/')
-      return youtubeUrl
+      const videoEmbedUrl = urlParser.create({videoInfo: urlParser.parse(url), format: 'embed'});
+      return videoEmbedUrl
     }
     return cleanUrl[0]
   }

--- a/packages/astro-notion/package.json
+++ b/packages/astro-notion/package.json
@@ -2,7 +2,7 @@
   "name": "@jcha0713/astro-notion",
   "description": "Data fetching tool that connects Astro and Notion",
   "type": "module",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "exports": {
     "./api": "./api/index.js",

--- a/packages/astro-notion/package.json
+++ b/packages/astro-notion/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@notionhq/client": "^1.0.4",
-    "astro-imagetools": "^0.6.9"
+    "astro-imagetools": "^0.6.9",
+    "js-video-url-parser": "^0.5.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,11 +29,13 @@ importers:
       '@notionhq/client': ^1.0.4
       astro: 1.0.0-beta.42
       astro-imagetools: ^0.6.9
+      js-video-url-parser: ^0.5.1
       prettier: ^2.6.2
       prettier-plugin-astro: ^0.0.12
     dependencies:
       '@notionhq/client': 1.0.4
       astro-imagetools: 0.6.9_astro@1.0.0-beta.42
+      js-video-url-parser: 0.5.1
     devDependencies:
       astro: 1.0.0-beta.42
       prettier: 2.6.2
@@ -921,6 +923,7 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+    dev: true
 
   /argparse/1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -959,7 +962,7 @@ packages:
       astro: '>=0.26 || >=1.0.0-beta'
     dependencies:
       '@astropub/codecs': 0.4.4
-      astro: 1.0.0-beta.42_sass@1.52.2
+      astro: 1.0.0-beta.42
       file-type: 17.1.1
       find-cache-dir: 3.3.2
       find-up: 6.3.0
@@ -1036,7 +1039,6 @@ packages:
       - stylus
       - supports-color
       - ts-node
-    dev: true
 
   /astro/1.0.0-beta.42_sass@1.52.2:
     resolution: {integrity: sha512-altpXVyiReQFmRwHV0/GDWrxE8YJ2bhINA6sO+7Qhyh2pbwD8FB80Vb6mHuKjksgTtdexJxrGKrMtAqXtq8oxQ==}
@@ -1105,6 +1107,7 @@ packages:
       - stylus
       - supports-color
       - ts-node
+    dev: true
 
   /asynckit/0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -1123,6 +1126,7 @@ packages:
   /binary-extensions/2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
+    dev: true
 
   /bl/4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -1256,6 +1260,7 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /chownr/1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -2176,6 +2181,7 @@ packages:
 
   /immutable/4.1.0:
     resolution: {integrity: sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==}
+    dev: true
 
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2227,6 +2233,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
+    dev: true
 
   /is-boolean-object/1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
@@ -2399,6 +2406,10 @@ packages:
 
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  /js-video-url-parser/0.5.1:
+    resolution: {integrity: sha512-/vwqT67k0AyIGMHAvSOt+n4JfrZWF7cPKgKswDO35yr27GfW4HtjpQVlTx6JLF45QuPm8mkzFHkZgFVnFm4x/w==}
+    dev: false
 
   /js-yaml/3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -3113,6 +3124,7 @@ packages:
   /normalize-path/3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /npm-run-path/5.1.0:
     resolution: {integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==}
@@ -3488,6 +3500,7 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
+    dev: true
 
   /recast/0.20.5:
     resolution: {integrity: sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==}
@@ -3663,6 +3676,7 @@ packages:
       chokidar: 3.5.3
       immutable: 4.1.0
       source-map-js: 1.0.2
+    dev: true
 
   /sax/1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
@@ -4202,7 +4216,6 @@ packages:
       rollup: 2.75.6
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /vite/2.9.10_sass@1.52.2:
     resolution: {integrity: sha512-TwZRuSMYjpTurLqXspct+HZE7ONiW9d+wSWgvADGxhDPPyoIcNywY+RX4ng+QpK30DCa1l/oZgi2PLZDibhzbQ==}
@@ -4227,6 +4240,7 @@ packages:
       sass: 1.52.2
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /vscode-css-languageservice/5.4.2:
     resolution: {integrity: sha512-DT7+7vfdT2HDNjDoXWtYJ0lVDdeDEdbMNdK4PKqUl2MS8g7PWt7J5G9B6k9lYox8nOfhCEjLnoNC3UKHHCR1lg==}


### PR DESCRIPTION
Noticed an error when videos are embedded in the notion page, they are not correctly displayed on astro components as the `iframe source` is incorrectly generated. Adding a library which seems to take care of this problem.

- Added [js-video-url-parser library](https://www.npmjs.com/package/js-video-url-parser) to extract video id and construct correct embed urls
- Updated `NonText.astro` to construct video url using new package
- Bumping package.json version to 0.1.4